### PR TITLE
add tests for 'bool' type and fix bug causing bools to always be 'true'

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -41,6 +41,7 @@ end
 @pgtype :varchar 1043
 @pgtype :text 25
 @pgtype :unknown 705
+@pgtype :numeric 1700
 
 typealias PGStringTypes Union(Type{PostgresType{:bpchar}},
                               Type{PostgresType{:varchar}},
@@ -73,6 +74,11 @@ jldata(::Type{PostgresType{:float8}}, ptr::Ptr{Uint8}) = parsefloat(Float64, byt
 
 jldata(::Type{PostgresType{:float4}}, ptr::Ptr{Uint8}) = parsefloat(Float32, bytestring(ptr))
 
+function jldata(::Type{PostgresType{:numeric}}, ptr::Ptr{Uint8})
+    s = bytestring(ptr)
+    return search(s, '.') == 0 ? BigInt(s) : BigFloat(s)
+end
+
 jldata(::PGStringTypes, ptr::Ptr{Uint8}) = bytestring(ptr)
 
 jldata(::Type{PostgresType{:bytea}}, ptr::Ptr{Uint8}) = bytestring(ptr) |> decode_bytea_hex
@@ -101,6 +107,10 @@ end
 
 function pgdata(::Type{PostgresType{:float4}}, ptr::Ptr{Uint8}, data::Number)
     ptr = storestring!(ptr, string(convert(Float32, data)))
+end
+
+function pgdata(::Type{PostgresType{:numeric}}, ptr::Ptr{Uint8}, data::Number)
+    ptr = storestring!(ptr, string(data))
 end
 
 function pgdata(::PGStringTypes, ptr::Ptr{Uint8}, data::Union(ASCIIString, UTF8String))

--- a/test/dbi.jl
+++ b/test/dbi.jl
@@ -47,20 +47,22 @@ function test_dbi()
             name varchar,
             color text,
             bin bytea,
-            is_planet bool
+            is_planet bool,
+            num_int numeric(80,0),
+            num_float numeric(80,10)
         );"""
 
     run(conn, create_str)
 
     data = Vector{Any}[
-        {1, 4, "Spam spam eggs and spam", "red", (Uint8)[0x01, 0x02, 0x03, 0x04], None},
-        {5, 8, "Michael Spam Palin", "blue", (Uint8)[], true},
-        {3, 16, None, None, None, false},
-        {NA, 32, "Foo", "green", (Uint8)[0xfe, 0xdc, 0xba, 0x98, 0x76], true}
+        {1, 4, "Spam spam eggs and spam", "red", (Uint8)[0x01, 0x02, 0x03, 0x04], None, BigInt(123), BigFloat("123.4567")},
+        {5, 8, "Michael Spam Palin", "blue", (Uint8)[], true, -3, BigFloat("-3.141592653")},
+        {3, 16, None, None, None, false, None, None},
+        {NA, 32, "Foo", "green", (Uint8)[0xfe, 0xdc, 0xba, 0x98, 0x76], true, 9876, BigFloat("9876.54321")}
     ]
 
-    insert_str = "INSERT INTO testdbi (combo, quant, name, color, bin, is_planet) " *
-                 "VALUES(\$1, \$2, \$3, \$4, \$5, \$6);"
+    insert_str = "INSERT INTO testdbi (combo, quant, name, color, bin, is_planet, num_int, num_float) " *
+                 "VALUES(\$1, \$2, \$3, \$4, \$5, \$6, \$7, \$8);"
 
     stmt = prepare(conn, insert_str)
     for row in data
@@ -69,7 +71,7 @@ function test_dbi()
     end
     finish(stmt)
 
-    stmt = prepare(conn, "SELECT combo, quant, name, color, bin, is_planet FROM testdbi ORDER BY id;")
+    stmt = prepare(conn, "SELECT combo, quant, name, color, bin, is_planet, num_int, num_float FROM testdbi ORDER BY id;")
     result = execute(stmt)
     testdberror(stmt, PostgreSQL.PGRES_TUPLES_OK)
     rows = fetchall(result)
@@ -82,6 +84,8 @@ function test_dbi()
     @test rows[4][4] == data[4][4]
     @test rows[4][5] == data[4][5]
     @test rows[4][6] == data[4][6]
+    @test rows[4][7] == data[4][7]
+    @test rows[4][8] == data[4][8]
 
     finish(stmt)
 
@@ -94,7 +98,7 @@ function test_dbi()
     testdberror(stmt, PostgreSQL.PGRES_COMMAND_OK)
     finish(stmt)
 
-    stmt = prepare(conn, "SELECT combo, quant, name, color, bin, is_planet FROM testdbi ORDER BY id;")
+    stmt = prepare(conn, "SELECT combo, quant, name, color, bin, is_planet, num_int, num_float FROM testdbi ORDER BY id;")
     result = execute(stmt)
     testdberror(stmt, PostgreSQL.PGRES_TUPLES_OK)
     rows = fetchall(result)
@@ -107,6 +111,8 @@ function test_dbi()
     @test rows[4][4] == data[4][4]
     @test rows[4][5] == data[4][5]
     @test rows[4][6] == data[4][6]
+    @test rows[4][7] == data[4][7]
+    @test rows[4][8] == data[4][8]
 
     finish(stmt)
 


### PR DESCRIPTION
I also checked haskell's postgresql driver and psycopg2's driver, and both
of them also only expect the values for bool to be of the form 't' and 'f'
