### PR TITLE
Fix Base.None depreciations to Union{} for Julia v0.4

### DIFF
--- a/src/libpq_common.jl
+++ b/src/libpq_common.jl
@@ -50,7 +50,7 @@ const PGF_BINARY = 1
 # Skipping MacroDefinition: PQsetdb(M_PGHOST,M_PGPORT,M_PGOPT,M_PGTTY,M_DBNAME)PQsetdbLogin(M_PGHOST,M_PGPORT,M_PGOPT,M_PGTTY,M_DBNAME,NULL,NULL)
 # Skipping MacroDefinition: PQfreeNotify(ptr)PQfreemem(ptr)
 const PQnoPasswordSupplied = "fe_sendauth: no password supplied\n"
-typealias _IO_lock_t None
+typealias _IO_lock_t Union{}
 typealias va_list Cint
 # typealias off_t __off_t
 # typealias ssize_t __ssize_t


### PR DESCRIPTION
This is a quick fix to bring the PostgreSQL package up to date with Julia v0.4.
Using `None` was depreciated in favor of `Union{}` (an empty set).

This simple fix prevents a couple depreciation warnings:
```julia
               _
   _       _ _(_)_     |  A fresh approach to technical computing
  (_)     | (_) (_)    |  Documentation: http://docs.julialang.org
   _ _   _| |_  __ _   |  Type "?help" for help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 0.4.0 (2015-10-08 06:20 UTC)
 _/ |\__'_|_|_|\__'_|  |  Official http://julialang.org/ release
|__/                   |  x86_64-apple-darwin13.4.0

julia> using PostgreSQL
WARNING: Base.None is deprecated, use Union{} instead.
  likely near /Users/pjames/.julia/v0.4/PostgreSQL/src/libpq_common.jl:53
WARNING: Base.None is deprecated, use Union{} instead.
  likely near /Users/pjames/.julia/v0.4/PostgreSQL/src/libpq_common.jl:53
julia> 
```