### PR TITLE
Update deprecated None to Union{} for Julia v0.4

### DIFF
--- a/src/dbi_impl.jl
+++ b/src/dbi_impl.jl
@@ -113,7 +113,7 @@ strlen(ptr::Ptr{UInt8}) = ccall((:strlen, LIBC), Csize_t, (Ptr{UInt8},), ptr)
 function getparams!(ptrs::Vector{Ptr{UInt8}}, params, types, sizes, lengths::Vector{Int32}, nulls)
     fill!(nulls, false)
     for i = 1:length(ptrs)
-        if params[i] === nothing || params[i] === NA || params[i] === None
+        if params[i] === nothing || params[i] === NA || params[i] === Union{}
             nulls[i] = true
         else
             ptrs[i] = pgdata(types[i], ptrs[i], params[i])
@@ -244,7 +244,7 @@ end
 
 # Assumes the row exists and has the structure described in PostgresResultHandle
 function unsafe_fetchrow(result::PostgresResultHandle, rownum::Integer)
-    return Any[PQgetisnull(result.ptr, rownum, i-1) == 1 ? None :
+    return Any[PQgetisnull(result.ptr, rownum, i-1) == 1 ? Union{} :
                jldata(datatype, PQgetvalue(result.ptr, rownum, i-1))
                for (i, datatype) in enumerate(result.types)]
 end

--- a/src/types.jl
+++ b/src/types.jl
@@ -85,7 +85,7 @@ jldata(::PGStringTypes, ptr::Ptr{UInt8}) = bytestring(ptr)
 
 jldata(::Type{PostgresType{:bytea}}, ptr::Ptr{UInt8}) = bytestring(ptr) |> decode_bytea_hex
 
-jldata(::Type{PostgresType{:unknown}}, ptr::Ptr{UInt8}) = None
+jldata(::Type{PostgresType{:unknown}}, ptr::Ptr{UInt8}) = Union{}
 
 jldata(::Type{PostgresType{:json}}, ptr::Ptr{UInt8}) = JSON.parse(bytestring(ptr))
 


### PR DESCRIPTION
Updated all the remaining `None` types to `Union{}`.