### PR TITLE
Adopt keyword arguments for connect function

### DIFF
--- a/test/connection.jl
+++ b/test/connection.jl
@@ -3,7 +3,7 @@ function test_connection()
     libpq = PostgreSQL.libpq_interface
 
     println("Checking basic connect")
-    conn = connect(Postgres, "localhost", "postgres", "", "julia_test")
+    conn = connect(Postgres, user="postgres", db="julia_test")
     @test isa(conn, PostgreSQL.PostgresDatabaseHandle)
     @test conn.status == PostgreSQL.CONNECTION_OK
     @test errcode(conn) == PostgreSQL.CONNECTION_OK
@@ -17,7 +17,7 @@ function test_connection()
     println("Basic connection passed")
 
     println("Checking doblock")
-    conn = connect(Postgres, "localhost", "postgres", "", "julia_test") do conn
+    conn = connect(Postgres, user="postgres", db="julia_test") do conn
         @test isa(conn, PostgreSQL.PostgresDatabaseHandle)
         @test conn.status == PostgreSQL.CONNECTION_OK
         @test errcode(conn) == PostgreSQL.CONNECTION_OK
@@ -28,7 +28,7 @@ function test_connection()
     println("Doblock passed")
 
     println("Testing connection with DSN string")
-    conn = connect(Postgres; dsn="postgresql://postgres@localhost:5432/julia_test")
+    conn = connect(Postgres, "postgresql://postgres@localhost:5432/julia_test")
     @test isa(conn, PostgreSQL.PostgresDatabaseHandle)
     @test conn.status == PostgreSQL.CONNECTION_OK
     @test errcode(conn) == PostgreSQL.CONNECTION_OK
@@ -42,7 +42,7 @@ function test_connection()
     println("DSN connection passed")
 
 #=    println("Testing connection with DSN string and doblock")
-    conn = connect(Postgres; dsn="postgresql://postgres@localhost:5432/postgres") do conn
+    conn = connect(Postgres, "postgresql://postgres@localhost:5432/postgres") do conn
         @test isa(conn, PostgreSQL.PostgresDatabaseHandle)
         @test conn.status == PostgreSQL.CONNECTION_OK
         @test errcode(conn) == PostgreSQL.CONNECTION_OK

--- a/test/dataframes_impl.jl
+++ b/test/dataframes_impl.jl
@@ -2,7 +2,7 @@ import DataFrames
 import DataArrays: isna
 
 function test_dataframes()
-    df = connect(Postgres, "localhost", "postgres", "", "julia_test") do conn
+    df = connect(Postgres, host="localhost", user="postgres", db="julia_test") do conn
         stmt = prepare(conn, "SELECT 4::integer as foo, 4.0::DOUBLE PRECISION as bar, " *
             "NULL::integer as foobar;")
         result = execute(stmt)
@@ -14,7 +14,7 @@ function test_dataframes()
     @test df[:bar] == Float64[4.0]
     @test isna(df[:foobar][1])
 
-    df2 = connect(Postgres, "localhost", "postgres", "", "julia_test") do conn
+    df2 = connect(Postgres, host="localhost", user="postgres", db="julia_test") do conn
         run(conn, """CREATE TEMPORARY TABLE dftable (foo integer, bar double precision,
             foobar integer);""")
         testdberror(conn, PostgreSQL.CONNECTION_OK)

--- a/test/dbi_impl.jl
+++ b/test/dbi_impl.jl
@@ -5,7 +5,7 @@ import Compat: @compat, parse
 function test_dbi()
     @test Postgres <: DBI.DatabaseSystem
 
-    conn = connect(Postgres, "localhost", "postgres", "", "julia_test")
+    conn = connect(Postgres, host="localhost", user="postgres", db="julia_test")
 
     @test isa(conn, DBI.DatabaseHandle)
     @test isdefined(conn, :status)
@@ -93,7 +93,7 @@ function test_dbi()
 
     disconnect(conn)
 
-    conn = connect(Postgres, "localhost", "postgres", "", "julia_test")
+    conn = connect(Postgres, host="localhost", user="postgres", db="julia_test")
     run(conn, create_str)
     stmt = prepare(conn, insert_str)
     executemany(stmt, data)
@@ -127,7 +127,7 @@ function test_dbi()
     disconnect(conn)
 
     # Test copy
-    conn = connect(Postgres, "localhost", "postgres", "", "julia_test")
+    conn = connect(Postgres, host="localhost", user="postgres", db="julia_test")
     create_str = """CREATE TEMPORARY TABLE testcopycsv(
       intdata INTEGER,
       otherint INTEGER,
@@ -153,7 +153,7 @@ function test_dbi()
     disconnect(conn)
 
     # Test arrays
-    conn = connect(Postgres, "localhost", "postgres", "", "julia_test")
+    conn = connect(Postgres, host="localhost", user="postgres", db="julia_test")
     create_str = """CREATE TEMPORARY TABLE testarrays(
       intdata INTEGER,
       floatdata DOUBLE PRECISION,

--- a/test/postgres.jl
+++ b/test/postgres.jl
@@ -1,6 +1,6 @@
 function testpostgres()
     PostgresType = PostgreSQL.PostgresType
-    conn = connect(Postgres, "localhost", "postgres", "", "julia_test")
+    conn = connect(Postgres, host="localhost", user="postgres", db="julia_test")
     run(conn, """CREATE TEMPORARY TABLE foobar (foo INTEGER PRIMARY KEY, bar DOUBLE PRECISION,
         foobar CHARACTER VARYING);""")
     stmt = prepare(conn, "INSERT INTO foobar (foo, bar, foobar) VALUES (\$1, \$2, \$3);")


### PR DESCRIPTION
Better to use keyword parameters: requires updating DBI.connect. Leave it to future.
