### PR TITLE
Fixed deprecated functions (bytestring, is, symbol)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ end
 ## Requirements
 
 * [DBI.jl](https://github.com/JuliaDB/DBI.jl)
-* [DataFrames.jl](https://github.com/JuliaStats/DataFrames.jl) >= v0.5.7
-* [DataArrays.jl](https://github.com/JuliaStats/DataArrays.jl) >= v0.1.2
+* [DataFrames.jl](https://github.com/JuliaStats/DataFrames.jl) >= v0.8.0
+* [DataArrays.jl](https://github.com/JuliaStats/DataArrays.jl) >= v0.3.4 for Julia 0.4, v0.3.8 for Julia 0.5
 * libpq shared library (comes with a standard PostgreSQL client installation)
 * Julia 0.4
 

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,5 @@
 julia 0.4
-DataFrames 0.6.6
+DataFrames 0.8.0
 DataArrays
 Compat
 JSON

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,4 +1,5 @@
 using BinDeps
+import Compat: @static, is_apple
 
 @BinDeps.setup
 
@@ -18,7 +19,7 @@ provides(Yum, "libpq5", libpq)
 provides(Yum, "postgresql-libs", libpq)
 provides(Pacman, "postgresql-libs", libpq)
 
-@osx_only begin
+@static if is_apple()
     using Homebrew
     provides(Homebrew.HB, "postgresql", libpq, os=:Darwin)
 end

--- a/src/dbi_impl.jl
+++ b/src/dbi_impl.jl
@@ -1,16 +1,16 @@
-import Compat: Libc, @compat
+import Compat: Libc, @static, is_windows
 
 function Base.connect(::Type{Postgres},
-                      host::AbstractString="",
-                      user::AbstractString="",
-                      passwd::AbstractString="",
-                      db::AbstractString="",
+                      host::AbstractString,
+                      user::AbstractString,
+                      passwd::AbstractString,
+                      db::AbstractString,
                       port::AbstractString="")
     conn = PQsetdbLogin(host, port, C_NULL, C_NULL, db, user, passwd)
     status = PQstatus(conn)
 
     if status != CONNECTION_OK
-        errmsg = bytestring(PQerrorMessage(conn))
+        errmsg = unsafe_string(PQerrorMessage(conn))
         PQfinish(conn)
         error(errmsg)
     end
@@ -36,7 +36,7 @@ function Base.connect(::Type{Postgres};
     conn = PQconnectdb(dsn)
     status = PQstatus(conn)
     if status != CONNECTION_OK
-        errmsg = bytestring(PQerrorMessage(conn))
+        errmsg = unsafe_string(PQerrorMessage(conn))
         PQfinish(conn)
         error(errmsg)
     end
@@ -60,7 +60,7 @@ function DBI.errcode(db::PostgresDatabaseHandle)
 end
 
 function DBI.errstring(db::PostgresDatabaseHandle)
-    return bytestring(PQerrorMessage(db.ptr))
+    return unsafe_string(PQerrorMessage(db.ptr))
 end
 
 function DBI.errcode(res::PostgresResultHandle)
@@ -68,7 +68,7 @@ function DBI.errcode(res::PostgresResultHandle)
 end
 
 function DBI.errstring(res::PostgresResultHandle)
-    return bytestring(PQresultErrorMessage(res.ptr))
+    return unsafe_string(PQresultErrorMessage(res.ptr))
 end
 
 DBI.errcode(stmt::PostgresStatementHandle) = DBI.errcode(stmt.result)
@@ -79,8 +79,8 @@ function checkerrclear(result::Ptr{PGresult})
 
     try
         if status == PGRES_FATAL_ERROR
-            statustext = bytestring(PQresStatus(status))
-            errmsg = bytestring(PQresultErrorMessage(result))
+            statustext = unsafe_string(PQresStatus(status))
+            errmsg = unsafe_string(PQresultErrorMessage(result))
             error("$statustext: $errmsg")
         end
     finally
@@ -89,18 +89,17 @@ function checkerrclear(result::Ptr{PGresult})
 end
 
 escapeliteral(db::PostgresDatabaseHandle, value) = value
-escapeliteral(db::PostgresDatabaseHandle, value::AbstractString) = escapeliteral(db, bytestring(value))
 
-function escapeliteral(db::PostgresDatabaseHandle, value::Union{ASCIIString, UTF8String})
+function escapeliteral(db::PostgresDatabaseHandle, value::AbstractString)
     strptr = PQescapeLiteral(db.ptr, value, sizeof(value))
-    str = bytestring(strptr)
+    str = unsafe_string(strptr)
     PQfreemem(strptr)
     return str
 end
 
-function escapeidentifier(db::PostgresDatabaseHandle, value::Union{ASCIIString, UTF8String})
+function escapeidentifier(db::PostgresDatabaseHandle, value::AbstractString)
     strptr = PQescapeIdentifier(db.ptr, value, sizeof(value))
-    str = bytestring(strptr)
+    str = unsafe_string(strptr)
     PQfreemem(strptr)
     return str
 end
@@ -109,8 +108,8 @@ Base.run(db::PostgresDatabaseHandle, sql::AbstractString) = checkerrclear(PQexec
 
 function checkcopyreturnval(db::PostgresDatabaseHandle, returnval::Int32)
     if returnval == -1
-        errcode = bytestring(DBI.errcode(db))
-        errmsg = bytestring(DBI.errmsg(db))
+        errcode = unsafe_string(DBI.errcode(db))
+        errmsg = unsafe_string(DBI.errmsg(db))
         error("Error $errcode: $errmsg")
     end
 end
@@ -131,14 +130,14 @@ function copy_from(db::PostgresDatabaseHandle, table::AbstractString,
     return checkerrclear(PQgetResult(db.ptr))
 end
 
-hashsql(sql::AbstractString) = bytestring(string("__", hash(sql), "__"))
+hashsql(sql::AbstractString) = unsafe_string(string("__", hash(sql), "__"))
 
 function getparamtypes(result::Ptr{PGresult})
     nparams = PQnparams(result)
-    return @compat [pgtype(OID{Int(PQparamtype(result, i-1))}) for i = 1:nparams]
+    return [pgtype(OID{Int(PQparamtype(result, i-1))}) for i = 1:nparams]
 end
 
-LIBC = @windows ? "msvcrt.dll" : :libc
+LIBC = @static is_windows() ? "msvcrt.dll" : :libc
 strlen(ptr::Ptr{UInt8}) = ccall((:strlen, LIBC), Csize_t, (Ptr{UInt8},), ptr)
 
 function getparams!(ptrs::Vector{Ptr{UInt8}}, params, types, sizes, lengths::Vector{Int32}, nulls)
@@ -281,9 +280,9 @@ function unsafe_fetchrow(result::PostgresResultHandle, rownum::Integer)
 end
 
 function unsafe_fetchcol_dataarray(result::PostgresResultHandle, colnum::Integer)
-    return @data([PQgetisnull(result.ptr, i, colnum) == 1 ? NA :
+    return Any[PQgetisnull(result.ptr, i, colnum) == 1 ? NA :
             jldata(result.types[colnum+1], PQgetvalue(result.ptr, i, colnum))
-            for i = 0:(PQntuples(result.ptr)-1)])
+            for i = 0:(PQntuples(result.ptr)-1)]
 end
 
 function DBI.fetchall(result::PostgresResultHandle)
@@ -293,7 +292,7 @@ end
 function DBI.fetchdf(result::PostgresResultHandle)
     df = DataFrame()
     for i = 0:(length(result.types)-1)
-        df[symbol(bytestring(PQfname(result.ptr, i)))] = unsafe_fetchcol_dataarray(result, i)
+        df[Symbol(unsafe_string(PQfname(result.ptr, i)))] = unsafe_fetchcol_dataarray(result, i)
     end
 
     return df

--- a/src/libpq_common.jl
+++ b/src/libpq_common.jl
@@ -1,5 +1,5 @@
 macro c(ret_type, func, arg_types, lib)
-    local args_in = Any[ symbol(string('a',x)) for x in 1:length(arg_types.args) ]
+    local args_in = Any[ Symbol(string('a',x)) for x in 1:length(arg_types.args) ]
     quote
         $(esc(func))($(args_in...)) = ccall( ($(string(func)), $(Expr(:quote, lib)) ),
                                             $ret_type, $arg_types, $(args_in...) )

--- a/src/libpq_interface.jl
+++ b/src/libpq_interface.jl
@@ -124,9 +124,6 @@ module libpq_interface
     @c Cint fscanf (Ptr{FILE}, Ptr{UInt8}) libpq
     @c Cint scanf (Ptr{UInt8},) libpq
     @c Cint sscanf (Ptr{UInt8}, Ptr{UInt8}) libpq
-    @c Cint fscanf (Ptr{FILE}, Ptr{UInt8}) libpq
-    @c Cint scanf (Ptr{UInt8},) libpq
-    @c Cint sscanf (Ptr{UInt8}, Ptr{UInt8}) libpq
     @c Cint fgetc (Ptr{FILE},) libpq
     @c Cint getc (Ptr{FILE},) libpq
     @c Cint getchar () libpq

--- a/src/types.jl
+++ b/src/types.jl
@@ -1,6 +1,6 @@
 import DataArrays: NAtype
 import JSON
-import Compat: Libc, unsafe_convert, parse, @compat
+import Compat: Libc, unsafe_convert, parse, @compat, String, unsafe_string
 
 abstract AbstractPostgresType
 type PostgresType{Name} <: AbstractPostgresType end
@@ -9,7 +9,30 @@ abstract AbstractOID
 type OID{N} <: AbstractOID end
 
 oid{T<:AbstractPostgresType}(t::Type{T}) = convert(OID, t)
-pgtype(t::Type) = convert(PostgresType, t)
+
+if VERSION < v"0.5-dev+4194"
+    import Compat
+
+    function pgtype(t::Type)
+        if t <: Compat.ASCIIString
+            convert(PostgresType, String)
+        elseif t <: Vector{Compat.ASCIIString}
+            convert(PostgresType, Vector{String})
+        else
+            convert(PostgresType, t)
+        end
+    end
+
+    function pgdata(::Type{PostgresType{:_varchar}}, ptr::Ptr{UInt8}, data::Vector{Compat.ASCIIString})
+        ptr = storestring!(ptr, string("{", join(data, ','), "}"))
+    end
+
+    function pgdata(::Type{PostgresType{:_text}}, ptr::Ptr{UInt8}, data::Vector{Compat.ASCIIString})
+        ptr = storestring!(ptr, string("{", join(data, ','), "}"))
+    end
+else
+    pgtype(t::Type) = convert(PostgresType, t)
+end
 
 Base.convert{T}(::Type{Oid}, ::Type{OID{T}}) = convert(Oid, T)
 
@@ -18,6 +41,7 @@ function newpgtype(pgtypename, oid, jltypes)
     Base.convert(::Type{PostgresType}, ::Type{OID{oid}}) = PostgresType{pgtypename}
 
     for t in jltypes
+        pgtypename in [:jsonb, :_text] && continue
         Base.convert(::Type{PostgresType}, ::Type{t}) = PostgresType{pgtypename}
     end
 end
@@ -33,7 +57,7 @@ newpgtype(:int2, 21, (Int16,))
 newpgtype(:float8, 701, (Float64,))
 newpgtype(:float4, 700, (Float32,))
 newpgtype(:bpchar, 1042, ())
-newpgtype(:varchar, 1043, (ASCIIString,UTF8String))
+newpgtype(:varchar, 1043, (String,))
 newpgtype(:text, 25, ())
 newpgtype(:numeric, 1700, (BigInt,BigFloat))
 newpgtype(:date, 1082, ())
@@ -50,8 +74,8 @@ newpgtype(:_int4, 1007, (Vector{Int32},))
 newpgtype(:_int2, 1005, (Vector{Int16},))
 newpgtype(:_float8, 1022, (Vector{Float64},))
 newpgtype(:_float4, 1021, (Vector{Float32},))
-newpgtype(:_varchar, 1015, (Vector{ASCIIString}, Vector{UTF8String}))
-newpgtype(:_text, 1009, (Vector{ASCIIString}, Vector{UTF8String}))
+newpgtype(:_varchar, 1015, (Vector{String},))
+newpgtype(:_text, 1009, (Vector{String},))
 
 
 typealias PGStringTypes Union{Type{PostgresType{:bpchar}},
@@ -74,54 +98,54 @@ function decode_bytea_hex(s::AbstractString)
     return hex2bytes(s[3:end])
 end
 
-jldata(::Type{PostgresType{:date}}, ptr::Ptr{UInt8}) = bytestring(ptr)
+jldata(::Type{PostgresType{:date}}, ptr::Ptr{UInt8}) = unsafe_string(ptr)
 
-jldata(::Type{PostgresType{:timestamp}}, ptr::Ptr{UInt8}) = bytestring(ptr)
+jldata(::Type{PostgresType{:timestamp}}, ptr::Ptr{UInt8}) = unsafe_string(ptr)
 
-jldata(::Type{PostgresType{:timestamptz}}, ptr::Ptr{UInt8}) = bytestring(ptr)
+jldata(::Type{PostgresType{:timestamptz}}, ptr::Ptr{UInt8}) = unsafe_string(ptr)
 
-jldata(::Type{PostgresType{:bool}}, ptr::Ptr{UInt8}) = bytestring(ptr) != "f"
+jldata(::Type{PostgresType{:bool}}, ptr::Ptr{UInt8}) = unsafe_string(ptr) != "f"
 
-jldata(::Type{PostgresType{:int8}}, ptr::Ptr{UInt8}) = parse(Int64, bytestring(ptr))
+jldata(::Type{PostgresType{:int8}}, ptr::Ptr{UInt8}) = parse(Int64, unsafe_string(ptr))
 
-jldata(::Type{PostgresType{:int4}}, ptr::Ptr{UInt8}) = parse(Int32, bytestring(ptr))
+jldata(::Type{PostgresType{:int4}}, ptr::Ptr{UInt8}) = parse(Int32, unsafe_string(ptr))
 
-jldata(::Type{PostgresType{:int2}}, ptr::Ptr{UInt8}) = parse(Int16, bytestring(ptr))
+jldata(::Type{PostgresType{:int2}}, ptr::Ptr{UInt8}) = parse(Int16, unsafe_string(ptr))
 
-jldata(::Type{PostgresType{:float8}}, ptr::Ptr{UInt8}) = parse(Float64, bytestring(ptr))
+jldata(::Type{PostgresType{:float8}}, ptr::Ptr{UInt8}) = parse(Float64, unsafe_string(ptr))
 
-jldata(::Type{PostgresType{:float4}}, ptr::Ptr{UInt8}) = parse(Float32, bytestring(ptr))
+jldata(::Type{PostgresType{:float4}}, ptr::Ptr{UInt8}) = parse(Float32, unsafe_string(ptr))
 
 function jldata(::Type{PostgresType{:numeric}}, ptr::Ptr{UInt8})
-    s = bytestring(ptr)
+    s = unsafe_string(ptr)
     return parse(search(s, '.') == 0 ? BigInt : BigFloat, s)
 end
 
-jldata(::PGStringTypes, ptr::Ptr{UInt8}) = bytestring(ptr)
+jldata(::PGStringTypes, ptr::Ptr{UInt8}) = unsafe_string(ptr)
 
-jldata(::Type{PostgresType{:bytea}}, ptr::Ptr{UInt8}) = bytestring(ptr) |> decode_bytea_hex
+jldata(::Type{PostgresType{:bytea}}, ptr::Ptr{UInt8}) = unsafe_string(ptr) |> decode_bytea_hex
 
 jldata(::Type{PostgresType{:unknown}}, ptr::Ptr{UInt8}) = Union{}
 
-jldata(::Type{PostgresType{:json}}, ptr::Ptr{UInt8}) = JSON.parse(bytestring(ptr))
+jldata(::Type{PostgresType{:json}}, ptr::Ptr{UInt8}) = JSON.parse(unsafe_string(ptr))
 
-jldata(::Type{PostgresType{:jsonb}}, ptr::Ptr{UInt8}) = JSON.parse(bytestring(ptr))
+jldata(::Type{PostgresType{:jsonb}}, ptr::Ptr{UInt8}) = JSON.parse(unsafe_string(ptr))
 
-jldata(::Type{PostgresType{:_bool}}, ptr::Ptr{UInt8}) = map(x -> x != "f", split(bytestring(ptr)[2:end-1], ','))
+jldata(::Type{PostgresType{:_bool}}, ptr::Ptr{UInt8}) = map(x -> x != "f", split(unsafe_string(ptr)[2:end-1], ','))
 
-jldata(::Type{PostgresType{:_int8}}, ptr::Ptr{UInt8}) = map(x -> parse(Int64, x), split(bytestring(ptr)[2:end-1], ','))
+jldata(::Type{PostgresType{:_int8}}, ptr::Ptr{UInt8}) = map(x -> parse(Int64, x), split(unsafe_string(ptr)[2:end-1], ','))
 
-jldata(::Type{PostgresType{:_int4}}, ptr::Ptr{UInt8}) = map(x -> parse(Int32, x), split(bytestring(ptr)[2:end-1], ','))
+jldata(::Type{PostgresType{:_int4}}, ptr::Ptr{UInt8}) = map(x -> parse(Int32, x), split(unsafe_string(ptr)[2:end-1], ','))
 
-jldata(::Type{PostgresType{:_int2}}, ptr::Ptr{UInt8}) = map(x -> parse(Int16, x), split(bytestring(ptr)[2:end-1], ','))
+jldata(::Type{PostgresType{:_int2}}, ptr::Ptr{UInt8}) = map(x -> parse(Int16, x), split(unsafe_string(ptr)[2:end-1], ','))
 
-jldata(::Type{PostgresType{:_float8}}, ptr::Ptr{UInt8}) = map(x -> parse(Float64, x), split(bytestring(ptr)[2:end-1], ','))
+jldata(::Type{PostgresType{:_float8}}, ptr::Ptr{UInt8}) = map(x -> parse(Float64, x), split(unsafe_string(ptr)[2:end-1], ','))
 
-jldata(::Type{PostgresType{:_float4}}, ptr::Ptr{UInt8}) = map(x -> parse(Float32, x), split(bytestring(ptr)[2:end-1], ','))
+jldata(::Type{PostgresType{:_float4}}, ptr::Ptr{UInt8}) = map(x -> parse(Float32, x), split(unsafe_string(ptr)[2:end-1], ','))
 
-jldata(::Type{PostgresType{:_varchar}}, ptr::Ptr{UInt8}) = convert(Vector{AbstractString}, split(bytestring(ptr)[2:end-1], ','))
+jldata(::Type{PostgresType{:_varchar}}, ptr::Ptr{UInt8}) = convert(Vector{AbstractString}, split(unsafe_string(ptr)[2:end-1], ','))
 
-jldata(::Type{PostgresType{:_text}}, ptr::Ptr{UInt8}) = convert(Vector{AbstractString}, split(bytestring(ptr)[2:end-1], ','))
+jldata(::Type{PostgresType{:_text}}, ptr::Ptr{UInt8}) = convert(Vector{AbstractString}, split(unsafe_string(ptr)[2:end-1], ','))
 
 function pgdata(::Type{PostgresType{:bool}}, ptr::Ptr{UInt8}, data::Bool)
     ptr = data ? storestring!(ptr, "TRUE") : storestring!(ptr, "FALSE")
@@ -151,29 +175,25 @@ function pgdata(::Type{PostgresType{:numeric}}, ptr::Ptr{UInt8}, data::Number)
     ptr = storestring!(ptr, string(data))
 end
 
-function pgdata(::PGStringTypes, ptr::Ptr{UInt8}, data::ByteString)
+function pgdata(::PGStringTypes, ptr::Ptr{UInt8}, data::AbstractString)
     ptr = storestring!(ptr, data)
 end
 
-function pgdata(::PGStringTypes, ptr::Ptr{UInt8}, data::AbstractString)
-    ptr = storestring!(ptr, bytestring(data))
-end
-
 function pgdata(::PostgresType{:date}, ptr::Ptr{UInt8}, data::AbstractString)
-    ptr = storestring!(ptr, bytestring(data))
+    ptr = storestring!(ptr, data)
     ptr = Dates.DateFormat(ptr)
 end
 
 function pgdata(::PostgresType{:timestamp}, ptr::Ptr{UInt8}, data::AbstractString)
-    ptr = storestring!(ptr, bytestring(data))
+    ptr = storestring!(ptr, data)
 end
 
 function pgdata(::PostgresType{:timestamptz}, ptr::Ptr{UInt8}, data::AbstractString)
-    ptr = storestring!(ptr, bytestring(data))
+    ptr = storestring!(ptr, data)
 end
 
 function pgdata(::Type{PostgresType{:bytea}}, ptr::Ptr{UInt8}, data::Vector{UInt8})
-    ptr = storestring!(ptr, bytestring("\\x", bytes2hex(data)))
+    ptr = storestring!(ptr, string("\\x", bytes2hex(data)))
 end
 
 function pgdata(::Type{PostgresType{:unknown}}, ptr::Ptr{UInt8}, data)
@@ -181,11 +201,11 @@ function pgdata(::Type{PostgresType{:unknown}}, ptr::Ptr{UInt8}, data)
 end
 
 function pgdata{T<:AbstractString}(::Type{PostgresType{:json}}, ptr::Ptr{UInt8}, data::Dict{T,Any})
-    ptr = storestring!(ptr, bytestring(JSON.json(data)))
+    ptr = storestring!(ptr, JSON.json(data))
 end
 
 function pgdata{T<:AbstractString}(::Type{PostgresType{:jsonb}}, ptr::Ptr{UInt8}, data::Dict{T,Any})
-    ptr = storestring!(ptr, bytestring(JSON.json(data)))
+    ptr = storestring!(ptr, JSON.json(data))
 end
 
 function pgdata(::Type{PostgresType{:_bool}}, ptr::Ptr{UInt8}, data::Vector{Bool})
@@ -212,19 +232,11 @@ function pgdata(::Type{PostgresType{:_float4}}, ptr::Ptr{UInt8}, data::Vector{Fl
     ptr = storestring!(ptr, string("{", join(data, ','), "}"))
 end
 
-function pgdata(::Type{PostgresType{:_varchar}}, ptr::Ptr{UInt8}, data::Vector{ASCIIString})
+function pgdata(::Type{PostgresType{:_varchar}}, ptr::Ptr{UInt8}, data::Vector{String})
     ptr = storestring!(ptr, string("{", join(data, ','), "}"))
 end
 
-function pgdata(::Type{PostgresType{:_varchar}}, ptr::Ptr{UInt8}, data::Vector{UTF8String})
-    ptr = storestring!(ptr, string("{", join(data, ','), "}"))
-end
-
-function pgdata(::Type{PostgresType{:_text}}, ptr::Ptr{UInt8}, data::Vector{ASCIIString})
-    ptr = storestring!(ptr, string("{", join(data, ','), "}"))
-end
-
-function pgdata(::Type{PostgresType{:_text}}, ptr::Ptr{UInt8}, data::Vector{UTF8String})
+function pgdata(::Type{PostgresType{:_text}}, ptr::Ptr{UInt8}, data::Vector{String})
     ptr = storestring!(ptr, string("{", join(data, ','), "}"))
 end
 

--- a/test/connection.jl
+++ b/test/connection.jl
@@ -1,3 +1,5 @@
+import Compat: unsafe_string
+
 function test_connection()
   println("Using libpq")
     libpq = PostgreSQL.libpq_interface
@@ -8,9 +10,9 @@ function test_connection()
     @test conn.status == PostgreSQL.CONNECTION_OK
     @test errcode(conn) == PostgreSQL.CONNECTION_OK
     @test !conn.closed
-    @test bytestring(libpq.PQdb(conn.ptr)) == "julia_test"
-    @test bytestring(libpq.PQuser(conn.ptr)) == "postgres"
-    @test bytestring(libpq.PQport(conn.ptr)) == "5432"
+    @test unsafe_string(libpq.PQdb(conn.ptr)) == "julia_test"
+    @test unsafe_string(libpq.PQuser(conn.ptr)) == "postgres"
+    @test unsafe_string(libpq.PQport(conn.ptr)) == "5432"
 
     disconnect(conn)
     @test conn.closed
@@ -33,9 +35,9 @@ function test_connection()
     @test conn.status == PostgreSQL.CONNECTION_OK
     @test errcode(conn) == PostgreSQL.CONNECTION_OK
     @test !conn.closed
-    @test bytestring(libpq.PQdb(conn.ptr)) == "julia_test"
-    @test bytestring(libpq.PQuser(conn.ptr)) == "postgres"
-    @test bytestring(libpq.PQport(conn.ptr)) == "5432"
+    @test unsafe_string(libpq.PQdb(conn.ptr)) == "julia_test"
+    @test unsafe_string(libpq.PQuser(conn.ptr)) == "postgres"
+    @test unsafe_string(libpq.PQport(conn.ptr)) == "5432"
 
     disconnect(conn)
     @test conn.closed

--- a/test/testutils.jl
+++ b/test/testutils.jl
@@ -1,6 +1,6 @@
 function testsameness(a, b)
     try
-        @test is(a, b)
+        @test ===(a, b)
     catch
         println(a, "::", typeof(a), " is not ", b, "::", typeof(b))
         rethrow()
@@ -12,7 +12,7 @@ function testdberror(dbobj, expected)
         @test errcode(dbobj) == expected
     catch
         println(errstring(dbobj))
-        println(bytestring(PostgreSQL.PQresStatus(expected)))
+        println(unsafe_string(PostgreSQL.PQresStatus(expected)))
         rethrow()
     end
 end


### PR DESCRIPTION
Hello

- Fixed deprecated functions: bytestring to unsafe_string, is to ===, symbol to Symbol
- Compat.ASCIIString for pgtype, pgdata
- requires DataFrames.jl v0.8.0

thanks.